### PR TITLE
Export toggle repository

### DIFF
--- a/src/unleash/index.ts
+++ b/src/unleash/index.ts
@@ -1,4 +1,5 @@
 export * from './decorators/if-enabled.decorator'
+export * from './repository/toggle-repository'
 export * from './unleash.constants'
 export * from './unleash.context'
 export * from './unleash.interfaces'

--- a/src/unleash/unleash.module.ts
+++ b/src/unleash/unleash.module.ts
@@ -44,7 +44,7 @@ const DEFAULT_INTERVAL = 15_000
     UnleashContext,
     UnleashService,
   ],
-  exports: [UnleashService, UnleashStrategiesModule],
+  exports: [UnleashService, UnleashStrategiesModule, ToggleRepository],
 })
 export class UnleashModule implements OnModuleInit {
   private readonly logger = new Logger(UnleashModule.name)
@@ -98,7 +98,7 @@ export class UnleashModule implements OnModuleInit {
       global: options?.global ?? true,
       module: UnleashModule,
       imports: [strategiesModule, clientModule],
-      exports: [clientModule, strategiesModule, UNLEASH_MODULE_OPTIONS],
+      exports: [clientModule, strategiesModule, UNLEASH_MODULE_OPTIONS, ToggleRepository],
       providers: [
         {
           provide: UNLEASH_MODULE_OPTIONS,
@@ -142,7 +142,7 @@ export class UnleashModule implements OnModuleInit {
       global: options?.global ?? true,
       module: UnleashModule,
       imports: [strategiesModule, clientModule],
-      exports: [clientModule, strategiesModule, UNLEASH_MODULE_OPTIONS],
+      exports: [clientModule, strategiesModule, UNLEASH_MODULE_OPTIONS, ToggleRepository],
       providers: [
         {
           provide: UNLEASH_MODULE_OPTIONS,


### PR DESCRIPTION
Thank you so much for this library 🙏

Adds `ToggleRepository` to exported libraries.

Useful if you need a list of all feature toggles, like when you're sending feature toggles from your backend to a SPA frontend and need to find all relevant features for a user.

I'm using this in our application since I temporarily published this branch as `@cobraz/nestjs-unleash@0.0.2-beta`